### PR TITLE
feat: visualize wage bands with plotly

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -6,3 +6,4 @@ altair>=5.0.0
 matplotlib>=3.7.0
 reportlab>=4.0.0
 streamlit_js_eval>=0.1.0
+plotly>=5.0.0


### PR DESCRIPTION
## Summary
- show required and break-even wage bands using Plotly with color-blind friendly markers
- include margin to required rate in scatter tooltips
- add Plotly as dependency

## Testing
- `pip install -r requirements.txt`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68b1ad917bd88323bd9f8083d333e6f6